### PR TITLE
Fix animation toggle and z-index calculation

### DIFF
--- a/lib/modal/window.html
+++ b/lib/modal/window.html
@@ -4,8 +4,8 @@ Copyright (C) 2013 - 2014 Angular Dart UI authors. Please see AUTHORS.md.
 https://github.com/akserg/angular.dart.ui
 All rights reserved.  Please see the LICENSE.md file.
 -->
-<div tabindex="-1" class="modal {{ m.windowClass }}" ng-class="{in: '${m.animate}'}" 
-    ng-style="{'z-index': '${1050 + index*10}', 'display': 'block'}" ng-click="m.close($event)">
+<div tabindex="-1" class="modal {{ m.windowClass }}" ng-class="{in: {{m.animate}}}"
+    ng-style="{'z-index': '{{1050 + index*10}}', 'display': 'block'}" ng-click="m.close($event)">
     <div class="modal-dialog">
       <div class="modal-content">
         <content></content>


### PR DESCRIPTION
modal/window.html contains expressions to calculate z-index and toggle animation class. Both seem to be ignored. Using {{...}} syntax instead works. Tested with angular-0.12.0.

The reason the ui demo works is because the bootstrap.css already defines z-index values matching what the element style is set to when the expressions are evaluated.
