### PR TITLE
Fixed ModalOptions.windowClass having no effect

### DIFF
--- a/lib/modal/modal.dart
+++ b/lib/modal/modal.dart
@@ -197,6 +197,7 @@ class Modal {
         if (options.animate != null) html += " animate=\"${options.animate}\"";
         if (options.backdrop != null) html += " backdrop=\"${options.backdrop}\"";
         if (options.keyboard != null) html += " keyboard=\"${options.keyboard}\"";
+        if (options.windowClass != null) html += " windowClass=\"${options.windowClass}\"";
         html += ">$content</modal-window>";
         //
         List<dom.Element> rootElements = toNodeList(html);


### PR DESCRIPTION
The Modal service did not pass the windowClass option to the ModalWindow component.
