### PR TITLE
#137 - Work around to tab heading issue.

### DIFF
--- a/lib/tabs/tab.dart
+++ b/lib/tabs/tab.dart
@@ -55,6 +55,17 @@ class TabComponent implements DetachAware, ScopeAware {
       onDeselectCallback();
     }
     _active = newValue;
+    _refreshTabHeading();
+  }
+
+  // Work around for dynamic tab heading issue.  It seems to have something to do with the digest cycle
+  // on tab and the ng-if adding the element back to dom.
+  void _refreshTabHeading() {
+    if(this._active && this.heading is Node) {
+      var clone = this.heading.clone(true);
+      (this.heading as Node).nodes.clear();
+      this.heading = clone;
+    }
   }
 
   @override

--- a/web/tabs/tabs_demo.html
+++ b/web/tabs/tabs_demo.html
@@ -20,13 +20,10 @@ All rights reserved.  Please see the LICENSE.md file.
     <tab ng-repeat="tab in tabs" heading="{{tab.title}}" active="tab.active" disabled="tab.disabled">
       {{tab.content}}
     </tab>
-<!--     <tab select="alertMe()"> -->
-<!--       <tab-heading> -->
-<!--         <i class="glyphicon glyphicon-bell"></i> Alert! -->
-<!--       </tab-heading> -->
-<!--       I've got an HTML heading, and a select callback. Pretty cool! -->
-<!--     </tab> -->
-    <tab select="alertMe()" heading="Alert!">
+    <tab select="alertMe()">
+      <tab-heading>
+        <i class="glyphicon glyphicon-bell"></i> Alert!
+      </tab-heading>
       I've got an HTML heading, and a select callback. Pretty cool!
     </tab>
 


### PR DESCRIPTION
The root problem seems to reside in the angular digest cycle and the ng-if when the tab is reactivated adding the tab-heading element back to the dom.  There is probably a more elegant solution to this problem, but this work around will at least make it functional until a better solution emerges.