### PR TITLE
Tab heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .project
+.packages
 .idea
 .children
 *.dart.js

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,5 @@
 * [Francesco Cina](https://github.com/ufoscout)
 * [Neeraj Mittal](https://github.com/neermitt)
 * [Robert Schütte](https://github.com/Roba1993)
+* [Jonathan Hughes](https://github.com/jonathanhughes)
+* [Martynas Kazlauskas](martynas@firmfirm.co)

--- a/lib/tabs/tab_heading.dart
+++ b/lib/tabs/tab_heading.dart
@@ -6,7 +6,8 @@ part of angular.ui.tabs;
 @Decorator(selector: 'tab-heading')
 class TabHeading {
   TabHeading(Element elem, TabComponent tab) {
-    elem.remove();
-    tab.heading = elem;
+    var clone = elem.clone(true);
+    elem.nodes.clear();
+    tab.heading = clone;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular_ui
-version: 0.6.8
+version: 0.6.9
 authors:
 - Sergey Akopkokhyants <akserg@gmail.com>
 - Tonis Pool <tonis.pool@gmail.com>

--- a/web/index.html
+++ b/web/index.html
@@ -24,7 +24,7 @@ All rights reserved.  Please see the LICENSE.md file.
     <popover-demo></popover-demo>
     <hr>
     
-    <h3>Toltip</h3>
+    <h3>Tooltip</h3>
     <tooltip-demo></tooltip-demo>
     <hr>
     

--- a/web/tabs/tabs_demo.html
+++ b/web/tabs/tabs_demo.html
@@ -22,11 +22,10 @@ All rights reserved.  Please see the LICENSE.md file.
     </tab>
     <tab select="alertMe()">
       <tab-heading>
-        <i class="glyphicon glyphicon-bell"></i> Alert!
+        <i class="glyphicon glyphicon-bell"></i><label>Alert!</label>
       </tab-heading>
       I've got an HTML heading, and a select callback. Pretty cool!
     </tab>
-
   </tabset>
 
   <hr />


### PR DESCRIPTION
This is a follow up PR for my previous tab heading fix which also fixes the tab heading for the first tab when no tabs are marked active (select was not called on initial render).  I also updated the markup on the demo page.