### PR TITLE
Typeahead-highlight search with words

### DIFF
--- a/lib/typeahead/typeahead_highlight.dart
+++ b/lib/typeahead/typeahead_highlight.dart
@@ -9,6 +9,20 @@ class TypeaheadHighlightFilter implements Function {
   }
 
   String call(String matchItem, String query) {
-    return (query == null || query.isEmpty) ? matchItem : ('$matchItem').replaceAllMapped(new RegExp(escapeRegexp(query), caseSensitive: false), (Match m)=> '<strong>${m[0]}</strong>');
+    if (query == null || query.isEmpty) {
+      return matchItem;
+    } else {
+      var queryArray = escapeRegexp(query).split(" ");
+      StringBuffer queryString = new StringBuffer();
+      if (queryArray.length > 1) {
+        queryString.writeAll(queryArray,'|');
+      } else {
+        queryString.write(queryArray[0]);
+      }
+      return ('$matchItem')
+          .replaceAllMapped(new RegExp(
+          queryString.toString().trim(), caseSensitive: false), (
+          Match m) =>  '<strong>${m[0]}</strong>');
+    }
   }
 }

--- a/test/unit/typeahead/typeahead_highlight_tests.dart
+++ b/test/unit/typeahead/typeahead_highlight_tests.dart
@@ -45,5 +45,11 @@ void typeaheadHighlightFilterTests() {
     it('should work correctly with numeric values', async(inject((){
       expect(highlightFilter('123', '2')).toEqual('1<strong>2</strong>3');
     })));
+
+    it('should highlight match results based on individual words', async(inject((){
+      expect(highlightFilter('John Doe 123', 'John 123')).toEqual('<strong>John</strong> Doe <strong>123</strong>');
+      expect(highlightFilter('John - Doe - Jane - Doe', 'John Jane')).toEqual('<strong>John</strong> - Doe - <strong>Jane</strong> - Doe');
+    })));
+
   });
 }


### PR DESCRIPTION
This change helps us highlight individual words on typeahead search
![screen shot 2016-07-27 at 7 24 26 pm](https://cloud.githubusercontent.com/assets/20703758/17249216/912e4d6c-55bc-11e6-8716-82a2939986f8.png)

All the existing test cases work along with the new one.
