### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ void main() {
 Use the angular-ui components as described below or in the [demo](http://akserg.github.io/angular.dart.ui.demo/index.html).
 
 
-##Bootstrap directives and components
+## Bootstrap directives and components
 
 - Checkbox and RadioButton
 - DropdownToggle
@@ -59,7 +59,7 @@ Use the angular-ui components as described below or in the [demo](http://akserg.
 
 *Note: Drag and Drop support is experimental feature and API can be changed at any time in the future.*
 
-##Credits
+## Credits
 
 - [Sergey Akopkokhyants](https://github.com/akserg)
 - [Tõnis Pool](https://github.com/poolik).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
